### PR TITLE
Tune httpd MPM based on available memory in container

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -36,6 +36,7 @@ COPY ./contrib/ /opt/app-root
 # random UID.
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/php55-php.conf && \
+    echo "IncludeOptional /opt/app-root/etc/conf.d/*.conf" >> /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
     mkdir /tmp/sessions && \
     chmod -R a+rwx /opt/rh/php55/root/etc && \

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -44,6 +44,7 @@ COPY ./contrib/ /opt/app-root
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/php55-php.conf && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
+    echo "IncludeOptional /opt/app-root/etc/conf.d/*.conf" >> /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     mkdir /tmp/sessions && \
     chmod -R a+rwx /opt/rh/php55/root/etc && \
     chmod -R a+rwx /opt/rh/httpd24/root/var/run/httpd && \

--- a/5.5/README.md
+++ b/5.5/README.md
@@ -124,6 +124,23 @@ You can also override the entire directory used to load the PHP configuration by
 * **PHP_INI_SCAN_DIR**
   * Path to scan for additional ini configuration files
 
+You can override the Apache [MPM prefork](https://httpd.apache.org/docs/2.4/mod/mpm_common.html)
+settings to increase the performance for of the PHP application. In case you set
+the Cgroup limits in Docker, the image will attempt to automatically set the
+optimal values. You can override this at any time by specifying the values
+yourself:
+
+* **HTTPD_START_SERVERS**
+  * The [StartServers](https://httpd.apache.org/docs/2.4/mod/mpm_common.html#startservers)
+    directive sets the number of child server processes created on startup.
+  * Default: 8
+* **HTTPD_MAX_REQUEST_WORKERS**
+  * The [MaxRequestWorkers](https://httpd.apache.org/docs/2.4/mod/mpm_common.html#maxrequestworkers)
+    directive sets the limit on the number of simultaneous requests that will be served.
+  * `MaxRequestWorkers` was called `MaxClients` before version httpd 2.3.13.
+  * Default: 256 (this is automatically tuned by setting Cgroup limits for the container using this formula:
+    `TOTAL_MEMORY / 15MB`. The 15MB is average size of a single httpd process.
+
 Source repository layout
 ------------------------
 

--- a/5.5/contrib/etc/conf.d/50-mpm-tuning.conf.template
+++ b/5.5/contrib/etc/conf.d/50-mpm-tuning.conf.template
@@ -1,0 +1,12 @@
+<IfModule mpm_prefork_module>
+    # This value should mirror what is set in MinSpareServers.
+    StartServers          ${HTTPD_START_SERVERS}
+    MinSpareServers       ${HTTPD_START_SERVERS}
+    MaxSpareServers       ${HTTPD_MAX_SPARE_SERVERS}
+    # The MaxRequestWorkers directive sets the limit on the number of simultaneous requests that will be served. 
+    # The default value, when no Cgroup limits are set is 256.
+    MaxRequestWorkers     ${HTTPD_MAX_REQUEST_WORKERS}
+    ServerLimit           ${HTTPD_MAX_REQUEST_WORKERS}
+    MaxRequestsPerChild   4000
+    MaxKeepAliveRequests  100
+</IfModule>

--- a/5.5/s2i/bin/run
+++ b/5.5/s2i/bin/run
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export_vars=$(cgroup-limits); export $export_vars
+
 # Default php.ini configuration values, all taken 
 # from php defaults.
 export ERROR_REPORTING=${ERROR_REPORTING:-E_ALL & ~E_NOTICE}
@@ -20,5 +22,25 @@ export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-/opt/rh/php55/root/etc/php.d}
 
 envsubst < /opt/app-root/etc/php.ini.template > /opt/rh/php55/root/etc/php.ini
 envsubst < /opt/app-root/etc/php.d/opcache.ini.template > /opt/rh/php55/root/etc/php.d/opcache.ini
+
+export HTTPD_START_SERVERS=${HTTPD_START_SERVERS:-8}
+export HTTPD_MAX_SPARE_SERVERS=$((HTTPD_START_SERVERS+10))
+
+if [ -n "${NO_MEMORY_LIMIT:-}" -o -z "${MEMORY_LIMIT_IN_BYTES:-}" ]; then
+  # 
+  export HTTPD_MAX_REQUEST_WORKERS=${HTTPD_MAX_REQUEST_WORKERS:-256}
+else
+  # A simple calculation for MaxRequestWorkers would be: Total Memory / Size Per Apache process.
+  # The total memory is determined from the Cgroups and the average size for the
+  # Apache process is estimated to 15MB.
+  max_clients_computed=$((MEMORY_LIMIT_IN_BYTES/1024/1024/15))
+  # The MaxClients should never be lower than StartServers, which is set to 5.
+  # In case the container has memory limit set to <64M we pin the MaxClients to 4.
+  [[ $max_clients_computed -le 4 ]] && max_clients_computed=4
+  export HTTPD_MAX_REQUEST_WORKERS=${HTTPD_MAX_REQUEST_WORKERS:-$max_clients_computed}
+  echo "-> Cgroups memory limit is set, using HTTPD_MAX_REQUEST_WORKERS=${HTTPD_MAX_REQUEST_WORKERS}"
+fi
+
+envsubst < /opt/app-root/etc/conf.d/50-mpm-tuning.conf.template > /opt/app-root/etc/conf.d/50-mpm-tuning.conf
 
 exec httpd -D FOREGROUND

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -36,6 +36,7 @@ COPY ./contrib/ /opt/app-root
 # writeable as OpenShift default security model is to run the container under
 # random UID.
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
+    echo "IncludeOptional /opt/app-root/etc/conf.d/*.conf" >> /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php56-php.conf && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
     mkdir /tmp/sessions && \

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -44,6 +44,7 @@ COPY ./contrib/ /opt/app-root
 RUN sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     sed -i '/php_value session.save_path/d' /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php56-php.conf && \
     head -n151 /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf | tail -n1 | grep "AllowOverride All" || exit && \
+    echo "IncludeOptional /opt/app-root/etc/conf.d/*.conf" >> /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf && \
     mkdir /tmp/sessions && \
     chmod -R a+rwx /etc/opt/rh/rh-php56 && \
     chmod -R a+rwx /opt/rh/httpd24/root/var/run/httpd && \

--- a/5.6/README.md
+++ b/5.6/README.md
@@ -124,6 +124,23 @@ You can also override the entire directory used to load the PHP configuration by
 * **PHP_INI_SCAN_DIR**
   * Path to scan for additional ini configuration files
 
+You can override the Apache [MPM prefork](https://httpd.apache.org/docs/2.4/mod/mpm_common.html)
+settings to increase the performance for of the PHP application. In case you set
+the Cgroup limits in Docker, the image will attempt to automatically set the
+optimal values. You can override this at any time by specifying the values
+yourself:
+
+* **HTTPD_START_SERVERS**
+  * The [StartServers](https://httpd.apache.org/docs/2.4/mod/mpm_common.html#startservers)
+    directive sets the number of child server processes created on startup.
+  * Default: 8
+* **HTTPD_MAX_REQUEST_WORKERS**
+  * The [MaxRequestWorkers](https://httpd.apache.org/docs/2.4/mod/mpm_common.html#maxrequestworkers)
+    directive sets the limit on the number of simultaneous requests that will be served.
+  * `MaxRequestWorkers` was called `MaxClients` before version httpd 2.3.13.
+  * Default: 256 (this is automatically tuned by setting Cgroup limits for the container using this formula:
+    `TOTAL_MEMORY / 15MB`. The 15MB is average size of a single httpd process.
+
 Source repository layout
 ------------------------
 

--- a/5.6/contrib/etc/conf.d/50-mpm-tuning.conf.template
+++ b/5.6/contrib/etc/conf.d/50-mpm-tuning.conf.template
@@ -1,0 +1,12 @@
+<IfModule mpm_prefork_module>
+    # This value should mirror what is set in MinSpareServers.
+    StartServers          ${HTTPD_START_SERVERS}
+    MinSpareServers       ${HTTPD_START_SERVERS}
+    MaxSpareServers       ${HTTPD_MAX_SPARE_SERVERS}
+    # The MaxRequestWorkers directive sets the limit on the number of simultaneous requests that will be served. 
+    # The default value, when no Cgroup limits are set is 256.
+    MaxRequestWorkers     ${HTTPD_MAX_REQUEST_WORKERS}
+    ServerLimit           ${HTTPD_MAX_REQUEST_WORKERS}
+    MaxRequestsPerChild   4000
+    MaxKeepAliveRequests  100
+</IfModule>

--- a/5.6/s2i/bin/run
+++ b/5.6/s2i/bin/run
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export_vars=$(cgroup-limits); export $export_vars
+
 # Default php.ini configuration values, all taken 
 # from php defaults.
 export ERROR_REPORTING=${ERROR_REPORTING:-E_ALL & ~E_NOTICE}
@@ -18,7 +20,27 @@ export OPCACHE_REVALIDATE_FREQ=${OPCACHE_REVALIDATE_FREQ:-2}
 export PHPRC=${PHPRC:-/etc/opt/rh/rh-php56/php.ini}
 export PHP_INI_SCAN_DIR=${PHP_INI_SCAN_DIR:-/etc/opt/rh/rh-php56/php.d}
 
-envsubst < /opt/app-root/etc/php.ini.template > $PHPRC
-envsubst < /opt/app-root/etc/php.d/10-opcache.ini.template > $PHP_INI_SCAN_DIR/10-opcache.ini
+envsubst < /opt/app-root/etc/php.ini.template > /etc/opt/rh/rh-php56/php.ini
+envsubst < /opt/app-root/etc/php.d/10-opcache.ini.template > /etc/opt/rh/rh-php56/10-opcache.ini
+
+export HTTPD_START_SERVERS=${HTTPD_START_SERVERS:-8}
+export HTTPD_MAX_SPARE_SERVERS=$((HTTPD_START_SERVERS+10))
+
+if [ -n "${NO_MEMORY_LIMIT:-}" -o -z "${MEMORY_LIMIT_IN_BYTES:-}" ]; then
+  # 
+  export HTTPD_MAX_REQUEST_WORKERS=${HTTPD_MAX_REQUEST_WORKERS:-256}
+else
+  # A simple calculation for MaxRequestWorkers would be: Total Memory / Size Per Apache process.
+  # The total memory is determined from the Cgroups and the average size for the
+  # Apache process is estimated to 15MB.
+  max_clients_computed=$((MEMORY_LIMIT_IN_BYTES/1024/1024/15))
+  # The MaxClients should never be lower than StartServers, which is set to 5.
+  # In case the container has memory limit set to <64M we pin the MaxClients to 4.
+  [[ $max_clients_computed -le 4 ]] && max_clients_computed=4
+  export HTTPD_MAX_REQUEST_WORKERS=${HTTPD_MAX_REQUEST_WORKERS:-$max_clients_computed}
+  echo "-> Cgroups memory limit is set, using HTTPD_MAX_REQUEST_WORKERS=${HTTPD_MAX_REQUEST_WORKERS}"
+fi
+
+envsubst < /opt/app-root/etc/conf.d/50-mpm-tuning.conf.template > /opt/app-root/etc/conf.d/50-mpm-tuning.conf
 
 exec httpd -D FOREGROUND


### PR DESCRIPTION
This PR introduces tuning of MPM values for the httpd server. You can override the defaults by passing these environment variables when starting this container:

* `HTTPD_START_SERVERS` - sets the number of child server processes created on startup
* `HTTPD_MAX_REQUEST_WORKERS` - (former name: MaxClients), sets the limit on the number of simultaneous requests that will be served.

If you don't specify them, the defaults are set to 8 servers and 256 workers (apache default). If you set the `--memory`, then the workers are determined by: total_memory/15MB where the 15MB is a magic value of estimated httpd process size (with PHP and all extensions enabled).

Fixes: https://github.com/openshift/s2i-base/issues/69